### PR TITLE
Cli norm

### DIFF
--- a/chromosight/utils/contacts_map.py
+++ b/chromosight/utils/contacts_map.py
@@ -223,6 +223,8 @@ class HicGenome:
             self.bins = self.clr.bins()[:]
         if norm == 'raw':
             self.use_norm = False
+        else:
+            self.use_norm = True
         # Bins with NaN weight are missing, matrix already balanced
         self.detectable_bins = np.flatnonzero(np.isfinite(self.bins.weight))
         print(

--- a/chromosight/utils/preprocessing.py
+++ b/chromosight/utils/preprocessing.py
@@ -279,8 +279,8 @@ def detrend(
         Whether to use isotonic regression to smooth the trend.
     fun : callable
         Function to use on each diagonal to compute the trend.
-    max_val : float
-        Maximum value in the detrended matrix.
+    max_val : float or None
+        Maximum value in the detrended matrix. Set to None to disable
 
     Returns
     -------
@@ -306,7 +306,8 @@ def detrend(
     except TypeError:
         pass
     clean_mat = clean_mat.tocsr()
-    clean_mat[clean_mat >= max_val] = max_val
+    if max_val is not None:
+        clean_mat[clean_mat >= max_val] = max_val
     return clean_mat
 
 

--- a/chromosight/utils/preprocessing.py
+++ b/chromosight/utils/preprocessing.py
@@ -296,18 +296,17 @@ def detrend(
         fun=fun,
     )
     y[np.isnan(y)] = 0.0
-
     # Detrending by the distance law
     clean_mat = matrix.tocoo()
     # clean_mat.data /= y_savgol[abs(clean_mat.row - clean_mat.col)]
     try:
-        clean_mat.data /= y[abs(clean_mat.row - clean_mat.col)]
+        clean_mat.data = clean_mat.data / y[abs(clean_mat.row - clean_mat.col)]
     # If no nonzero value in matrix, do nothing
     except TypeError:
         pass
     clean_mat = clean_mat.tocsr()
     if max_val is not None:
-        clean_mat[clean_mat >= max_val] = max_val
+        clean_mat[clean_mat >= max_val] = 1
     return clean_mat
 
 

--- a/tests/test_chromosight.py
+++ b/tests/test_chromosight.py
@@ -12,7 +12,7 @@ DUMPDIR = tempfile.TemporaryDirectory()
 # Select a bunch of arguments that are relevant to test and generate
 # all possible combinations. Put them in a datastructure that can be digested
 # by docopt
-detect_args = ["-I", "-n", f"-d {DUMPDIR.name}"]
+detect_args = ["-I", "--no-plotting", f"-d {DUMPDIR.name}"]
 detect_combos = []
 for i in range(0, len(detect_args) + 1):
     args_combos = list(it.combinations(detect_args, i))

--- a/tests/test_contacts_map.py
+++ b/tests/test_contacts_map.py
@@ -69,7 +69,7 @@ def test_hic_genome(path):
 def test_hic_genome_normalize(path):
     """Test if normalization of HicGenome object yields expected results"""
     hic_genome = ccm.HicGenome(path)
-    hic_genome.normalize(force_norm=True)
+    hic_genome.normalize(norm=True)
 
 
 class TestHicGenome(unittest.TestCase):

--- a/tests/test_contacts_map.py
+++ b/tests/test_contacts_map.py
@@ -69,7 +69,8 @@ def test_hic_genome(path):
 def test_hic_genome_normalize(path):
     """Test if normalization of HicGenome object yields expected results"""
     hic_genome = ccm.HicGenome(path)
-    hic_genome.normalize(norm=True)
+    hic_genome.normalize(norm='raw')
+    hic_genome.normalize(norm='auto')
 
 
 class TestHicGenome(unittest.TestCase):


### PR DESCRIPTION
This branch adds support for raw matrices. This is also useful in cases where normalized values are hard-coded in pixels of cooler files. It replaces the CLI flag `--force-norm` by a `--norm={raw,force,auto}` option. By default, the behaviour is the same as before (`auto`), but setting to `raw` will cause chromosight to ignore the weights in the cool file and use raw pixels.