### PR TITLE
Rect speedup

### DIFF
--- a/chromosight/utils/detection.py
+++ b/chromosight/utils/detection.py
@@ -704,7 +704,7 @@ def _xcorr2_sparse(signal, kernel, threshold=1e-6):
             else:
                 for ki in range(km):
                     subkernel_sp = sp.diags(
-                        kernel[ki, :], np.arange(kn), shape=(sn - kn + 1, sn), format="csr",
+                        np.array(kernel[ki, :]).flatten(), np.arange(kn), shape=(sn - kn + 1, sn), format="csr",
                     )
                     out += signal[ki : sm - km + 1 + ki, :].dot(subkernel_sp.T)
 

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -290,6 +290,24 @@ def test_xcorr2_constant(signal):
         atol=1e-4,
     )
 
+@params(*gauss1_mats)
+def test_xcorr2_rectangle(signal):
+    """Check if xcorr2 yields correct results with rectangle kernels"""
+    rect_ker = gauss_kernel[:, 2:6]
+    conv_rect= cud.xcorr2(
+        signal,
+        rect_ker,
+    ).toarray()
+    conv_square  = cud.xcorr2(
+        signal,
+        gauss_kernel,
+    ).toarray()
+    rect_r, rect_c = np.where(conv_rect == conv_rect.max())
+    square_r, square_c = np.where(conv_square == conv_square.max())
+    # Hit from truncated kernel must be no further than 1 pixel from
+    # hit from square kernel
+    assert  abs(square_r[0] - rect_r[0]) < 2
+    assert  abs(square_c[0] - rect_c[0]) < 2
 
 @params(*gauss1_mats)
 def test_normxcorr2(signal):


### PR DESCRIPTION
This pull request provides a speedup to the convolution algorithm in xcorr2 when using rectangular kernels.
* xcorr2 now checks the largest dimension of the kernel (row or col) and runs the inner loop on the largest dimensions. This minimizes the number of operations to run in python.
* adds unit test to validate result of xcorr2 on rectangular kernels